### PR TITLE
Add method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-##opentsdb-goclient
+##Caicloud fork of opentsdb-goclient
+
+### ChangeLog
+* time type from int64 to time.Time
+* Add a method: GetTimeAndFloat64Values
 
 ###Backgroud
 OpenTSDB is a distributed, scalable Time Series Database (TSDB) written on top of HBase.

--- a/client/query.go
+++ b/client/query.go
@@ -246,6 +246,24 @@ func (qri *QueryRespItem) GetDataPoints() []*DataPoint {
 	return datapoints
 }
 
+// GetTimeAndFloat64Values returns the real ascending datapoints from the information of the related QueryRespItem.
+func (qri *QueryRespItem) GetTimeAndFloat64Values() ([]time.Time, []float64) {
+	timestampStrs := qri.getSortedTimestampStrs()
+	values := make([]float64, len(timestampStrs))
+	timeStamps := make([]time.Time, len(timestampStrs))
+	for i, timestampStr := range timestampStrs {
+		timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+		if err != nil {
+			continue
+		}
+		timeStamps[i] = time.Unix(timestampInt, 0)
+		if val, ok := qri.Dps[timestampStr].(float64); ok {
+			values[i] = val
+		}
+	}
+	return timeStamps, values
+}
+
 // getSortedTimestampStrs returns a slice of the ascending timestamp with
 // string format for the Dps of the related QueryRespItem instance.
 func (qri *QueryRespItem) getSortedTimestampStrs() []string {

--- a/sample.go
+++ b/sample.go
@@ -59,7 +59,7 @@ func main() {
 		time.Sleep(500 * time.Millisecond)
 		data := client.DataPoint{
 			Metric:    name[i],
-			Timestamp: time.Now().Unix(),
+			Timestamp: time.Now(),
 			Value:     rand.Float64(),
 		}
 		data.Tags = tags


### PR DESCRIPTION
咱们 monitoring 存的很多数据是 float64 的，goclient 默认返回的是 interface 的 value 和 string 类型的时间戳。如果不在这里 parse 时间戳和value，就要在monitoring-server那里写parse，比较麻烦，而且要重新做for循环，一个点一个点转换数据类型。所以直接在 GetTimeAndFloat64Values 的循环里写好了数据转换